### PR TITLE
Bug 1069186  - create mozril quirks for shinano

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -16,6 +16,8 @@ PRODUCT_COPY_FILES += \
 PRODUCT_PROPERTY_OVERRIDES += \
   ro.moz.nfc.enabled=true \
   ro.moz.bluetooth.backend=bluetoothd \
+  ro.moz.ril.ipv6=true \
+  ro.moz.ril.signal_extra_int=true \
 
 PRODUCT_PACKAGES += \
   bcm4339.ko  \


### PR DESCRIPTION
To add |ro.moz.ril.ipv6| for ipv6, and |ro.moz.ril.signal_extra_int| for signal strength
