### PR TITLE
Bug 1169505 - Remove libExtendedExtractor.so

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -323,6 +323,7 @@ copy_files_glob "*.so" "system/vendor/lib/soundfx" "audio"
 
 COMMON_VENDOR_LIBS_EXCLUDED="
 	libwvm.so
+	libExtendedExtractor.so
 	"
 
 copy_files_glob "lib*.so" "system/vendor/lib" "" "$COMMON_VENDOR_LIBS_EXCLUDED"


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1169505
