### PR TITLE
Bug 1177146 - Add mozril quirk ro.moz.ril.avlbl_nw_extra_str to shinano-common

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -24,6 +24,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
   ro.moz.bluetooth.backend=bluetoothd \
   ro.moz.ril.ipv6=true \
   ro.moz.ril.signal_extra_int=true \
+  ro.moz.ril.avlbl_nw_extra_str=true \
 
 PRODUCT_PACKAGES += \
   bcm4339.ko  \


### PR DESCRIPTION
Please see [bug 117146](https://bugzilla.mozilla.org/show_bug.cgi?id=1177146).
