### PR TITLE
Bug 1195166 - For aries, ignore the usbdisk volume (which we don't ot…

### DIFF
--- a/volume.cfg
+++ b/volume.cfg
@@ -1,1 +1,2 @@
 create sdcard /storage/emulated/legacy
+ignore usbdisk


### PR DESCRIPTION
…herwise support)
