### PR TITLE
Bug 1134573 - [Shinano][Aries] Missing cpufreq governor configuration

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -416,6 +416,7 @@ COMMON_ETC="
 	sap.conf
 	sec_config
 	sensor_def_qcomdev.conf
+	set_governor.sh
 	ramdump_ssr.xml
 	libnfc-brcm.conf
 	libnfc-nxp.conf

--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -582,3 +582,8 @@ service fakebattery /system/bin/fakebattery
 service sensorservice /system/bin/sensorservice
     class main
     user root
+
+# This is usually run in init.sony-platform.rc but depends
+# on Android's boot animation service, which we don't have.
+on property:sys.boot_completed=1
+    start set-governor


### PR DESCRIPTION
Sony delays configuring the kernel governor until the boot animation
has finished which speeds up boot significantly. Unfortunately on B2G
init.svc.bootanim does not exist, so the correct governor config is
never used.

Furthermore (On KK builds) we do not even have set_governor.sh on
the system partition!

With the correct governor config we can expect significant battery life
and power usage improvements.

Signed-off-by: Adam Farden adam@farden.cz
