### PR TITLE
Bug 1136512 - Sony Z3C - nfcd should build with Z3 compatiable libnfc-nci library

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -13,6 +13,8 @@ PRODUCT_COPY_FILES += \
   $(LOCAL_PATH)/hostapd.conf:system/etc/hostapd/hostapd_default.conf \
   hardware/sony/timekeep/gecko/TimeKeepService.js:system/b2g/distribution/bundles/timekeep/TimeKeepService.js \
   hardware/sony/timekeep/gecko/chrome.manifest:system/b2g/distribution/bundles/timekeep/chrome.manifest \
+  $(LOCAL_PATH)/nfc/libnfc-brcm.conf:system/etc/libnfc-brcm.conf \
+  $(LOCAL_PATH)/nfc/libnfc-nxp.conf:system/etc/libnfc-nxp.conf \
   system/bluetooth/data/main.le.conf:system/etc/bluetooth/main.conf \
 
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
@@ -34,6 +36,7 @@ PRODUCT_PACKAGES += \
   rilproxy    \
   init.sh     \
   timekeep    \
+  nfc_nci.pn54x.default \
 
 # Needed to make sure bug 1177411 cannot resurface
 export FOTA_DEVICE_DATA_FILES := /data/misc/dhcp/dhcpcd-wlan0.lease

--- a/extract-files.sh
+++ b/extract-files.sh
@@ -234,7 +234,6 @@ copy_files "$COMMON_ROOT_SBIN" "root/sbin" "root"
 copy_files_glob "*.png" "root/res/images/charger" "root"
 
 COMMON_LIBS="
-	libnfc-nci.so
 	libnfc_ndef.so
 	libcnefeatureconfig.so
 	libgps.utils.so
@@ -394,7 +393,6 @@ COMMON_HW="
 	camera.qcom.so
 	gps.default.so
 	keystore.qcom.so
-	nfc_nci_pn547.msm8974.so
 	lights.default.so
 	libdisplay.default.so
 	"
@@ -417,8 +415,6 @@ COMMON_ETC="
 	sec_config
 	sensor_def_qcomdev.conf
 	ramdump_ssr.xml
-	libnfc-brcm.conf
-	libnfc-nxp.conf
 	pre_hw_config.sh
 	"
 copy_files "$COMMON_ETC" "system/etc" "etc"

--- a/nfc/libnfc-brcm.conf
+++ b/nfc/libnfc-brcm.conf
@@ -1,0 +1,318 @@
+## this file is used by Broadcom's Hardware Abstraction Layer at external/libnfc-nci/halimpl/
+
+###############################################################################
+# Application options
+APPL_TRACE_LEVEL=0xFF
+PROTOCOL_TRACE_LEVEL=0xFFFFFFFF
+
+###############################################################################
+# performance measurement
+# Change this setting to control how often USERIAL log the performance (throughput)
+# data on read/write/poll
+# defailt is to log performance dara for every 100 read or write
+#REPORT_PERFORMANCE_MEASURE=100
+
+###############################################################################
+# File used for NFA storage
+NFA_STORAGE="/data/nfc"
+
+###############################################################################
+# Snooze Mode Settings
+#
+#  By default snooze mode is enabled.  Set SNOOZE_MODE_CFG byte[0] to 0
+#  to disable.
+#
+#  If SNOOZE_MODE_CFG is not provided, the default settings are used:
+#  They are as follows:
+#       8             Sleep Mode (0=Disabled 1=UART 8=SPI/I2C)
+#       0             Idle Threshold Host
+#       0             Idle Threshold HC
+#       0             NFC Wake active mode (0=ActiveLow 1=ActiveHigh)
+#       1             Host Wake active mode (0=ActiveLow 1=ActiveHigh)
+#
+#SNOOZE_MODE_CFG={08:00:00:00:01}
+
+###############################################################################
+# Insert a delay in milliseconds after NFC_WAKE and before write to NFCC
+NFC_WAKE_DELAY=20
+
+###############################################################################
+# Various Delay settings (in ms) used in USERIAL
+#  POWER_ON_DELAY
+#    Delay after turning on chip, before writing to transport (default 300)
+#  PRE_POWER_OFF_DELAY
+#    Delay after deasserting NFC-Wake before turn off chip (default 0)
+#  POST_POWER_OFF_DELAY
+#    Delay after turning off chip, before USERIAL_close returns (default 0)
+#
+#POWER_ON_DELAY=300
+#PRE_POWER_OFF_DELAY=0
+#POST_POWER_OFF_DELAY=0
+
+###############################################################################
+# LPTD mode configuration
+#  byte[0] is the length of the remaining bytes in this value
+#     if set to 0, LPTD params will NOT be sent to NFCC (i.e. disabled).
+#  byte[1] is the param id it should be set to B9.
+#  byte[2] is the length of the LPTD parameters
+#  byte[3] indicates if LPTD is enabled
+#     if set to 0, LPTD will be disabled (parameters will still be sent).
+#  byte[4-n] are the LPTD parameters.
+#  By default, LPTD is enabled and default settings are used.
+#  See nfc_hal_dm_cfg.c for defaults
+LPTD_CFG={23:B9:21:01:02:FF:FF:04:A0:0F:40:00:80:02:02:10:00:00:00:31:0C:30:00:00:00:00:00:00:00:00:00:00:00:00:00:00}
+
+###############################################################################
+# Startup Configuration (100 bytes maximum)
+#
+# For the 0xCA parameter, byte[9] (marked by 'AA') is for UICC0, and byte[10] (marked by BB) is
+#    for UICC1.  The values are defined as:
+#   0 : UICCx only supports ISO_DEP in low power mode.
+#   2 : UICCx only supports Mifare in low power mode.
+#   3 : UICCx supports both ISO_DEP and Mifare in low power mode.
+#
+#                                                                          AA BB
+NFA_DM_START_UP_CFG={1F:CB:01:01:A5:01:01:CA:14:00:00:00:00:06:E8:03:00:00:00:00:00:00:00:00:00:00:00:00:00:80:01:01}
+
+###############################################################################
+# Startup Vendor Specific Configuration (100 bytes maximum);
+#  byte[0] TLV total len = 0x5
+#  byte[1] NCI_MTS_CMD|NCI_GID_PROP = 0x2f
+#  byte[2] NCI_MSG_FRAME_LOG = 0x9
+#  byte[3] 2
+#  byte[4] 0=turn off RF frame logging; 1=turn on
+#  byte[5] 0=turn off SWP frame logging; 1=turn on
+#  NFA_DM_START_UP_VSC_CFG={05:2F:09:02:01:01}
+
+###############################################################################
+# Total Duration Configuration (msec)
+# Min=0x0000 Max=0xFFFF(65535)
+NFA_DM_DISC_DURATION_POLL=300
+
+###############################################################################
+# Antenna Configuration - This data is used when setting 0xC8 config item
+# at startup (before discovery is started).  If not used, no value is sent.
+#
+# The settings for this value are documented here:
+# http://wcgbu.broadcom.com/wpan/PM/Project%20Document%20Library/bcm20791B0/
+#   Design/Doc/PHY%20register%20settings/BCM20791-B2-1027-02_PHY_Recommended_Reg_Settings.xlsx
+# This document is maintained by Paul Forshaw.
+#
+# The values marked as ?? should be tweaked per antenna or customer/app:
+# {20:C8:1E:06:??:00:??:??:??:00:??:24:00:1C:00:75:00:77:00:76:00:1C:00:03:00:0A:00:??:01:00:00:40:04}
+# array[0] = 0x20 is length of the payload from array[1] to the end
+# array[1] = 0xC8 is PREINIT_DSP_CFG
+#PREINIT_DSP_CFG={20:C8:1E:06:1F:00:0F:03:3C:00:04:24:00:1C:00:75:00:77:00:76:00:1C:00:03:00:0A:00:48:01:00:00:40:04}
+
+###############################################################################
+# Configure crystal frequency when internal LPO can't detect the frequency.
+#XTAL_FREQUENCY=0
+###############################################################################
+# Configure the default Destination Gate used by HCI (the default is 4, which
+# is the ETSI loopback gate.
+NFA_HCI_DEFAULT_DEST_GATE=0xF0
+
+###############################################################################
+# Configure the single default SE to use.  The default is to use the first
+# SE that is detected by the stack.  This value might be used when the phone
+# supports multiple SE (e.g. 0xF3 and 0xF4) but you want to force it to use
+# one of them (e.g. 0xF4).
+#ACTIVE_SE=0xF3
+
+###############################################################################
+# Configure the NFC Extras to open and use a static pipe.  If the value is
+# not set or set to 0, then the default is use a dynamic pipe based on a
+# destination gate (see NFA_HCI_DEFAULT_DEST_GATE).  Note there is a value
+# for each UICC (where F3="UICC0" and F4="UICC1")
+#NFA_HCI_STATIC_PIPE_ID_F3=0x70
+#NFA_HCI_STATIC_PIPE_ID_01=0x19
+NFA_HCI_STATIC_PIPE_ID_C0=0x19
+###############################################################################
+# When disconnecting from Oberthur secure element, perform a warm-reset of
+# the secure element to deselect the applet.
+# The default hex value of the command is 0x3.  If this variable is undefined,
+# then this feature is not used.
+OBERTHUR_WARM_RESET_COMMAND=0x03
+
+###############################################################################
+# Force UICC to only listen to the following technology(s).
+# The bits are defined as tNFA_TECHNOLOGY_MASK in nfa_api.h.
+# Default is NFA_TECHNOLOGY_MASK_A | NFA_TECHNOLOGY_MASK_B | NFA_TECHNOLOGY_MASK_F
+UICC_LISTEN_TECH_MASK=0x87
+
+###############################################################################
+# Allow UICC to be powered off if there is no traffic.
+# Timeout is in ms. If set to 0, then UICC will not be powered off.
+#UICC_IDLE_TIMEOUT=30000
+UICC_IDLE_TIMEOUT=0
+
+###############################################################################
+# AID for Empty Select command
+# If specified, this AID will be substituted when an Empty SELECT command is
+# detected.  The first byte is the length of the AID.  Maximum length is 16.
+AID_FOR_EMPTY_SELECT={08:A0:00:00:01:51:00:00:00}
+###############################################################################
+# Maximum Number of Credits to be allowed by the NFCC
+#   This value overrides what the NFCC specifices allowing the host to have
+#   the control to work-around transport limitations.  If this value does
+#   not exist or is set to 0, the NFCC will provide the number of credits.
+MAX_RF_DATA_CREDITS=1
+
+###############################################################################
+# This setting allows you to disable registering the T4t Virtual SE that causes
+# the NFCC to send PPSE requests to the DH.
+# The default setting is enabled (i.e. T4t Virtual SE is registered).
+#REGISTER_VIRTUAL_SE=1
+
+###############################################################################
+# When screen is turned off, specify the desired power state of the controller.
+# 0: power-off-sleep state; DEFAULT
+# 1: full-power state
+# 2: screen-off card-emulation (CE4/CE3/CE1 modes are used)
+SCREEN_OFF_POWER_STATE=1
+
+###############################################################################
+# Firmware patch file
+#  If the value is not set then patch download is disabled.
+FW_PATCH="/vendor/firmware/bcm2079x_firmware.ncd"
+
+###############################################################################
+# Firmware pre-patch file (sent before the above patch file)
+#  If the value is not set then pre-patch is not used.
+FW_PRE_PATCH="/vendor/firmware/bcm2079x_pre_firmware.ncd"
+
+###############################################################################
+# Firmware patch format
+#   1 = HCD
+#   2 = NCD (default)
+#NFA_CONFIG_FORMAT=2
+
+###############################################################################
+# SPD Debug mode
+#  If set to 1, any failure of downloading a patch will trigger a hard-stop
+#SPD_DEBUG=0
+
+###############################################################################
+# SPD Max Retry Count
+#  The number of attempts to download a patch before giving up (defualt is 3).
+#  Note, this resets after a power-cycle.
+#SPD_MAX_RETRY_COUNT=3
+
+###############################################################################
+# transport driver
+#
+# TRANSPORT_DRIVER=<driver>
+#
+#  where <driver> can be, for example:
+#    "/dev/ttyS"        (UART)
+#    "/dev/bcmi2cnfc"   (I2C)
+#    "hwtun"            (HW Tunnel)
+#    "/dev/bcmspinfc"   (SPI)
+#    "/dev/btusb0"      (BT USB)
+TRANSPORT_DRIVER="/dev/bcm2079x"
+
+###############################################################################
+# power control driver
+# Specify a kernel driver that support ioctl commands to control NFC_EN and
+# NFC_WAKE gpio signals.
+#
+# POWER_CONTRL_DRIVER=<driver>
+#  where <driver> can be, for example:
+#    "/dev/nfcpower"
+#    "/dev/bcmi2cnfc"   (I2C)
+#    "/dev/bcmspinfc"   (SPI)
+#    i2c and spi driver may be used to control NFC_EN and NFC_WAKE signal
+POWER_CONTROL_DRIVER="/dev/bcm2079x"
+
+###############################################################################
+# I2C transport driver options
+#
+BCMI2CNFC_ADDRESS=0
+
+###############################################################################
+# I2C transport driver try to read multiple packets in read() if data is available
+# remove the comment below to enable this feature
+#READ_MULTIPLE_PACKETS=1
+
+###############################################################################
+# SPI transport driver options
+#SPI_NEGOTIATION={0A:F0:00:01:00:00:00:FF:FF:00:00}
+
+###############################################################################
+# UART transport driver options
+#
+# PORT=1,2,3,...
+# BAUD=115200, 19200, 9600, 4800,
+# DATABITS=8, 7, 6, 5
+# PARITY="even" | "odd" | "none"
+# STOPBITS="0" | "1" | "1.5" | "2"
+
+#UART_PORT=2
+#UART_BAUD=115200
+#UART_DATABITS=8
+#UART_PARITY="none"
+#UART_STOPBITS="1"
+
+###############################################################################
+# Insert a delay in microseconds per byte after a write to NFCC.
+# after writing a block of data to the NFCC, delay this an amopunt of time before
+# writing next block of data.  the delay is calculated as below
+#   NFC_WRITE_DELAY * (number of byte written) / 1000 milliseconds
+# e.g. after 259 bytes is written, delay (259 * 20 / 1000) 5 ms before next write
+NFC_WRITE_DELAY=20
+
+###############################################################################
+# Maximum Number of Credits to be allowed by the NFCC
+#   This value overrides what the NFCC specifices allowing the host to have
+#   the control to work-around transport limitations.  If this value does
+#   not exist or is set to 0, the NFCC will provide the number of credits.
+MAX_RF_DATA_CREDITS=1
+
+###############################################################################
+# Antenna Configuration - This data is used when setting 0xC8 config item
+# at startup (before discovery is started).  If not used, no value is sent.
+#
+# The settings for this value are documented here:
+# http://wcgbu.broadcom.com/wpan/PM/Project%20Document%20Library/bcm20791B0/
+#   Design/Doc/PHY%20register%20settings/BCM20791-B2-1027-02_PHY_Recommended_Reg_Settings.xlsx
+# This document is maintained by Paul Forshaw.
+#
+# The values marked as ?? should be tweaked per antenna or customer/app:
+# {20:C8:1E:06:??:00:??:??:??:00:??:24:00:1C:00:75:00:77:00:76:00:1C:00:03:00:0A:00:??:01:00:00:40:04}
+# array[0] = 0x20 is length of the payload from array[1] to the end
+# array[1] = 0xC8 is PREINIT_DSP_CFG
+#PREINIT_DSP_CFG={20:C8:1E:06:1F:00:0F:03:3C:00:04:24:00:1C:00:75:00:77:00:76:00:1C:00:03:00:0A:00:48:01:00:00:40:04}
+
+
+###############################################################################
+# Force tag polling for the following technology(s).
+# The bits are defined as tNFA_TECHNOLOGY_MASK in nfa_api.h.
+# Default is NFA_TECHNOLOGY_MASK_A | NFA_TECHNOLOGY_MASK_B |
+#            NFA_TECHNOLOGY_MASK_F | NFA_TECHNOLOGY_MASK_ISO15693 |
+#            NFA_TECHNOLOGY_MASK_B_PRIME | NFA_TECHNOLOGY_MASK_KOVIO |
+#            NFA_TECHNOLOGY_MASK_A_ACTIVE | NFA_TECHNOLOGY_MASK_F_ACTIVE.
+#
+# Notable bits:
+# NFA_TECHNOLOGY_MASK_A             0x01    /* NFC Technology A             */
+# NFA_TECHNOLOGY_MASK_B             0x02    /* NFC Technology B             */
+# NFA_TECHNOLOGY_MASK_F             0x04    /* NFC Technology F             */
+# NFA_TECHNOLOGY_MASK_ISO15693	    0x08    /* Proprietary Technology       */
+# NFA_TECHNOLOGY_MASK_KOVIO	        0x20    /* Proprietary Technology       */
+# NFA_TECHNOLOGY_MASK_A_ACTIVE      0x40    /* NFC Technology A active mode */
+# NFA_TECHNOLOGY_MASK_F_ACTIVE      0x80    /* NFC Technology F active mode */
+POLLING_TECH_MASK=0xEF
+
+###############################################################################
+# Force P2P to only listen for the following technology(s).
+# The bits are defined as tNFA_TECHNOLOGY_MASK in nfa_api.h.
+# Default is NFA_TECHNOLOGY_MASK_A | NFA_TECHNOLOGY_MASK_F |
+#            NFA_TECHNOLOGY_MASK_A_ACTIVE | NFA_TECHNOLOGY_MASK_F_ACTIVE
+#
+# Notable bits:
+# NFA_TECHNOLOGY_MASK_A	            0x01    /* NFC Technology A             */
+# NFA_TECHNOLOGY_MASK_F	            0x04    /* NFC Technology F             */
+# NFA_TECHNOLOGY_MASK_A_ACTIVE      0x40    /* NFC Technology A active mode */
+# NFA_TECHNOLOGY_MASK_F_ACTIVE      0x80    /* NFC Technology F active mode */
+P2P_LISTEN_TECH_MASK=0x84
+
+PRESERVE_STORAGE=0x01

--- a/nfc/libnfc-nxp.conf
+++ b/nfc/libnfc-nxp.conf
@@ -1,0 +1,461 @@
+## This file is used by NFC NXP NCI HAL(external/libnfc-nci/halimpl/pn547)
+## and NFC Service Java Native Interface Extensions (packages/apps/Nfc/nci/jni/extns/pn547)
+
+###############################################################################
+# Application options
+# Logging Levels
+# NXPLOG_DEFAULT_LOGLEVEL    0x01
+# ANDROID_LOG_DEBUG          0x03
+# ANDROID_LOG_WARN           0x02
+# ANDROID_LOG_ERROR          0x01
+# ANDROID_LOG_SILENT         0x00
+#
+NXPLOG_EXTNS_LOGLEVEL=0x01
+NXPLOG_NCIHAL_LOGLEVEL=0x01
+NXPLOG_NCIX_LOGLEVEL=0x01
+NXPLOG_NCIR_LOGLEVEL=0x01
+NXPLOG_FWDNLD_LOGLEVEL=0x01
+NXPLOG_TML_LOGLEVEL=0x01
+
+###############################################################################
+# Extension for Mifare reader enable
+#    0x00 - Disabled
+#    0x01 - Enabled
+MIFARE_READER_ENABLE=0x01
+
+###############################################################################
+# File location for Firmware
+#FW_STORAGE="/vendor/firmware/libpn547_fw.so"
+
+###############################################################################
+# System clock source selection configuration
+#    CLK_SRC_XTAL     - 0x01
+#    CLK_SRC_PLL      - 0x02
+NXP_SYS_CLK_SRC_SEL=0x02
+
+###############################################################################
+# System clock frequency selection configuration for PLL
+#    CLK_FREQ_13MHZ   - 0x01
+#    CLK_FREQ_19_2MHZ - 0x02
+#    CLK_FREQ_24MHZ   - 0x03
+#    CLK_FREQ_26MHZ   - 0x04
+#    CLK_FREQ_38_4MHZ - 0x05
+#    CLK_FREQ_52MHZ   - 0x06
+NXP_SYS_CLK_FREQ_SEL=0x02
+
+###############################################################################
+# The timeout value to be used for clock request acknowledgment
+# min value = 0x01 to max = 0x1A
+NXP_SYS_CLOCK_TO_CFG=0x02
+
+###############################################################################
+# NXP proprietary settings
+NXP_ACT_PROP_EXTN={2F, 02, 00}
+
+###############################################################################
+# NFC forum profile settings
+NXP_NFC_PROFILE_EXTN={20, 02, 05, 01, A0, 44, 01, 00}
+
+###############################################################################
+# Standby enable settings
+#    0x00 - Disabled
+#    0x01 - Enabled
+NXP_CORE_STANDBY={2F, 00, 01, 01}
+
+###############################################################################
+# NXP RF PLM (NO BOOSTER) configuration settings for FW VERSION = 08.01.1F
+###############################################################################
+#    A0, 0D, 03, 00, 40, 03                RF_CLIF_BOOT                CLIF_ANA_NFCLD_REG
+#    A0, 0D, 03, 04, 43, A0                RF_CLIF_CFG_INITIATOR       CLIF_ANA_PBF_CONTROL_REG
+#    A0, 0D, 03, 04, FF, 05                RF_CLIF_CFG_INITIATOR       SMU_PMU_REG (0x40024010)
+#    A0, 0D, 06, 06, 44, A3, 90, 03, 00    RF_CLIF_CFG_TARGET          CLIF_ANA_RX_REG
+#    A0, 0D, 06, 06, 30, BF, 00, 20, 00    RF_CLIF_CFG_TARGET          CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#    A0, 0D, 06, 06, 2F, 8F, 05, 80, 11    RF_CLIF_CFG_TARGET          CLIF_SIGPRO_ADCBCM_CONFIG_REG
+#    A0, 0D, 04, 06, 03, 00, 70            RF_CLIF_CFG_TARGET          CLIF_TRANSCEIVE_CONTROL_REG
+#    A0, 0D, 03, 06, 48, 10                RF_CLIF_CFG_TARGET          CLIF_ANA_CLK_MAN_REG
+#    A0, 0D, 03, 06, 43, 2C                RF_CLIF_CFG_TARGET          CLIF_ANA_PBF_CONTROL_REG
+#    A0, 0D, 06, 06, 42, 01, 00, F1, FF    RF_CLIF_CFG_TARGET          CLIF_ANA_TX_AMPLITUDE_REG
+#    A0, 0D, 06, 06, 41, 01, 00, 00, 00    RF_CLIF_CFG_TARGET          CLIF_ANA_TX_CLK_CONTROL_REG
+#    A0, 0D, 03, 06, 37, 00                RF_CLIF_CFG_TARGET          CLIF_TX_CONTROL_REG
+#    A0, 0D, 03, 06, 16, 00                RF_CLIF_CFG_TARGET          CLIF_TX_UNDERSHOOT_CONFIG_REG
+#    A0, 0D, 03, 06, 15, 00                RF_CLIF_CFG_TARGET          CLIF_TX_OVERSHOOT_CONFIG_REG
+#    A0, 0D, 06, 06, FF, 05, 00, 06, 00    RF_CLIF_CFG_TARGET          SMU_PMU_REG (0x40024010)
+#    A0, 0D, 06, 08, 44, 00, 00, 00, 00    RF_CLIF_CFG_I_PASSIVE       CLIF_ANA_RX_REG
+#    A0, 0D, 06, 20, 4A, 00, 00, 00, 00    RF_CLIF_CFG_TECHNO_I_TX15693CLIF_ANA_TX_SHAPE_CONTROL_REG
+#    A0, 0D, 06, 20, 42, 88, 10, FF, FF    RF_CLIF_CFG_TECHNO_I_TX15693CLIF_ANA_TX_AMPLITUDE_REG
+#    A0, 0D, 03, 20, 16, 00                RF_CLIF_CFG_TECHNO_I_TX15693CLIF_TX_UNDERSHOOT_CONFIG_REG
+#    A0, 0D, 03, 20, 15, 00                RF_CLIF_CFG_TECHNO_I_TX15693CLIF_TX_OVERSHOOT_CONFIG_REG
+#    A0, 0D, 06, 22, 44, 29, 00, 02, 00    RF_CLIF_CFG_TECHNO_I_RX15693CLIF_ANA_RX_REG
+#    A0, 0D, 06, 22, 2D, 50, 44, 0C, 00    RF_CLIF_CFG_TECHNO_I_RX15693CLIF_SIGPRO_RM_CONFIG1_REG
+#    A0, 0D, 04, 32, 03, 40, 3D            RF_CLIF_CFG_BR_106_I_TXA    CLIF_TRANSCEIVE_CONTROL_REG
+#    A0, 0D, 06, 32, 42, F8, 10, FF, FF    RF_CLIF_CFG_BR_106_I_TXA    CLIF_ANA_TX_AMPLITUDE_REG
+#    A0, 0D, 03, 32, 16, 19                RF_CLIF_CFG_BR_106_I_TXA    CLIF_TX_UNDERSHOOT_CONFIG_REG
+#    A0, 0D, 03, 32, 15, 01                RF_CLIF_CFG_BR_106_I_TXA    CLIF_TX_OVERSHOOT_CONFIG_REG
+#    A0, 0D, 03, 32, 0D, 26                RF_CLIF_CFG_BR_106_I_TXA    CLIF_TX_DATA_MOD_REG
+#    A0, 0D, 03, 32, 14, 26                RF_CLIF_CFG_BR_106_I_TXA    CLIF_TX_SYMBOL23_MOD_REG
+#    A0, 0D, 06, 32, 4A, 53, 07, 01, 1B    RF_CLIF_CFG_BR_106_I_TXA    CLIF_ANA_TX_SHAPE_CONTROL_REG
+#    A0, 0D, 06, 34, 2D, DC, 50, 0C, 00    RF_CLIF_CFG_BR_106_I_RXA_P  CLIF_SIGPRO_RM_CONFIG1_REG
+#    A0, 0D, 06, 34, 44, 21, 00, 02, 00    RF_CLIF_CFG_BR_106_I_RXA_P  CLIF_ANA_RX_REG
+#    A0, 0D, 06, 35, 44, 21, 00, 02, 00    RF_CLIF_CFG_BR_106_I_RXA_P  CLIF_ANA_RX_REG
+#    A0, 0D, 06, 38, 4A, 56, 07, 01, 1B    RF_CLIF_CFG_BR_212_I_TXA    CLIF_ANA_TX_SHAPE_CONTROL_REG
+#    A0, 0D, 06, 38, 42, 68, 10, FF, FF    RF_CLIF_CFG_BR_212_I_TXA    CLIF_ANA_TX_AMPLITUDE_REG
+#    A0, 0D, 03, 38, 16, 00                RF_CLIF_CFG_BR_212_I_TXA    CLIF_TX_UNDERSHOOT_CONFIG_REG
+#    A0, 0D, 03, 38, 15, 00                RF_CLIF_CFG_BR_212_I_TXA    CLIF_TX_OVERSHOOT_CONFIG_REG
+#    A0, 0D, 06, 3A, 2D, 15, 57, 1F, 00    RF_CLIF_CFG_BR_212_I_RXA    CLIF_SIGPRO_RM_CONFIG1_REG
+#    A0, 0D, 06, 3C, 4A, 56, 07, 01, 1B    RF_CLIF_CFG_BR_424_I_TXA    CLIF_ANA_TX_SHAPE_CONTROL_REG
+#    A0, 0D, 06, 3C, 42, 68, 10, FF, FF    RF_CLIF_CFG_BR_424_I_TXA    CLIF_ANA_TX_AMPLITUDE_REG
+#    A0, 0D, 03, 3C, 16, 00                RF_CLIF_CFG_BR_424_I_TXA    CLIF_TX_UNDERSHOOT_CONFIG_REG
+#    A0, 0D, 03, 3C, 15, 00                RF_CLIF_CFG_BR_424_I_TXA    CLIF_TX_OVERSHOOT_CONFIG_REG
+#    A0, 0D, 06, 3E, 2D, 15, 57, 1F, 00    RF_CLIF_CFG_BR_424_I_RXA    CLIF_SIGPRO_RM_CONFIG1_REG
+#    A0, 0D, 06, 40, 42, F0, 10, FF, FF    RF_CLIF_CFG_BR_848_I_TXA    CLIF_ANA_TX_AMPLITUDE_REG
+#    A0, 0D, 03, 40, 0D, 03                RF_CLIF_CFG_BR_848_I_TXA    CLIF_TX_DATA_MOD_REG
+#    A0, 0D, 03, 40, 14, 03                RF_CLIF_CFG_BR_848_I_TXA    CLIF_TX_SYMBOL23_MOD_REG
+#    A0, 0D, 06, 40, 4A, 15, 07, 00, 00    RF_CLIF_CFG_BR_848_I_TXA    CLIF_ANA_TX_SHAPE_CONTROL_REG
+#    A0, 0D, 03, 40, 16, 00                RF_CLIF_CFG_BR_848_I_TXA    CLIF_TX_UNDERSHOOT_CONFIG_REG
+#    A0, 0D, 03, 40, 15, 00                RF_CLIF_CFG_BR_848_I_TXA    CLIF_TX_OVERSHOOT_CONFIG_REG
+#    A0, 0D, 06, 42, 2D, DD, 33, 0F, 00    RF_CLIF_CFG_BR_848_I_RXA    CLIF_SIGPRO_RM_CONFIG1_REG
+#    A0, 0D, 06, 46, 44, 21, 00, 02, 00    RF_CLIF_CFG_BR_106_I_RXB    CLIF_ANA_RX_REG
+#    A0, 0D, 06, 46, 2D, 05, 48, 0C, 00    RF_CLIF_CFG_BR_106_I_RXB    CLIF_SIGPRO_RM_CONFIG1_REG
+#    A0, 0D, 06, 44, 4A, 43, 07, 01, 07    RF_CLIF_CFG_BR_106_I_TXB    CLIF_ANA_TX_SHAPE_CONTROL_REG
+#    A0, 0D, 06, 44, 42, 90, 10, FF, FF    RF_CLIF_CFG_BR_106_I_TXB    CLIF_ANA_TX_AMPLITUDE_REG
+#    A0, 0D, 03, 44, 16, 00                RF_CLIF_CFG_BR_106_I_TXB    CLIF_TX_UNDERSHOOT_CONFIG_REG
+#    A0, 0D, 03, 44, 15, 00                RF_CLIF_CFG_BR_106_I_TXB    CLIF_TX_OVERSHOOT_CONFIG_REG
+#    A0, 0D, 06, 4A, 44, 21, 00, 02, 00    RF_CLIF_CFG_BR_212_I_RXB    CLIF_ANA_RX_REG
+#    A0, 0D, 06, 4A, 2D, 05, 48, 0C, 00    RF_CLIF_CFG_BR_212_I_RXB    CLIF_SIGPRO_RM_CONFIG1_REG
+#    A0, 0D, 06, 48, 4A, 43, 07, 01, 07    RF_CLIF_CFG_BR_212_I_TXB    CLIF_ANA_TX_SHAPE_CONTROL_REG
+#    A0, 0D, 06, 48, 42, 88, 10, FF, FF    RF_CLIF_CFG_BR_212_I_TXB    CLIF_ANA_TX_AMPLITUDE_REG
+#    A0, 0D, 03, 48, 16, 00                RF_CLIF_CFG_BR_212_I_TXB    CLIF_TX_UNDERSHOOT_CONFIG_REG
+#    A0, 0D, 03, 48, 15, 00                RF_CLIF_CFG_BR_212_I_TXB    CLIF_TX_OVERSHOOT_CONFIG_REG
+#    A0, 0D, 06, 4E, 44, 21, 00, 02, 00    RF_CLIF_CFG_BR_424_I_RXB    CLIF_ANA_RX_REG
+#    A0, 0D, 06, 4E, 2D, 05, 48, 0C, 00    RF_CLIF_CFG_BR_424_I_RXB    CLIF_SIGPRO_RM_CONFIG1_REG
+#    A0, 0D, 06, 4C, 4A, 43, 07, 01, 07    RF_CLIF_CFG_BR_424_I_TXB    CLIF_ANA_TX_SHAPE_CONTROL_REG
+#    A0, 0D, 06, 4C, 42, 88, 10, FF, FF    RF_CLIF_CFG_BR_424_I_TXB    CLIF_ANA_TX_AMPLITUDE_REG
+#    A0, 0D, 03, 4C, 16, 00                RF_CLIF_CFG_BR_424_I_TXB    CLIF_TX_UNDERSHOOT_CONFIG_REG
+#    A0, 0D, 03, 4C, 15, 00                RF_CLIF_CFG_BR_424_I_TXB    CLIF_TX_OVERSHOOT_CONFIG_REG
+#    A0, 0D, 06, 52, 44, 21, 00, 02, 00    RF_CLIF_CFG_BR_848_I_RXB    CLIF_ANA_RX_REG
+#    A0, 0D, 06, 52, 2D, 05, 48, 0C, 00    RF_CLIF_CFG_BR_848_I_RXB    CLIF_SIGPRO_RM_CONFIG1_REG
+#    A0, 0D, 06, 50, 42, 90, 10, FF, FF    RF_CLIF_CFG_BR_848_I_TXB    CLIF_ANA_TX_AMPLITUDE_REG
+#    A0, 0D, 06, 50, 4A, 32, 07, 01, 07    RF_CLIF_CFG_BR_848_I_TXB    CLIF_ANA_TX_SHAPE_CONTROL_REG
+#    A0, 0D, 03, 50, 16, 00                RF_CLIF_CFG_BR_848_I_TXB    CLIF_TX_UNDERSHOOT_CONFIG_REG
+#    A0, 0D, 03, 50, 15, 00                RF_CLIF_CFG_BR_848_I_TXB    CLIF_TX_OVERSHOOT_CONFIG_REG
+#    A0, 0D, 06, 56, 2D, 05, CC, 0C, 00    RF_CLIF_CFG_BR_212_I_RXF_P  CLIF_SIGPRO_RM_CONFIG1_REG
+#    A0, 0D, 06, 56, 44, 21, 00, 02, 00    RF_CLIF_CFG_BR_212_I_RXF_P  CLIF_ANA_RX_REG
+#    A0, 0D, 06, 5C, 2D, 05, CC, 0C, 00    RF_CLIF_CFG_BR_424_I_RXF_P  CLIF_SIGPRO_RM_CONFIG1_REG
+#    A0, 0D, 06, 5C, 44, 21, 00, 02, 00    RF_CLIF_CFG_BR_424_I_RXF_P  CLIF_ANA_RX_REG
+#    A0, 0D, 06, 54, 42, 90, 10, FF, FF    RF_CLIF_CFG_BR_212_I_TXF    CLIF_ANA_TX_AMPLITUDE_REG
+#    A0, 0D, 06, 54, 4A, 43, 07, 01, 07    RF_CLIF_CFG_BR_212_I_TXF    CLIF_ANA_TX_SHAPE_CONTROL_REG
+#    A0, 0D, 03, 54, 16, 00                RF_CLIF_CFG_BR_212_I_TXF    CLIF_TX_UNDERSHOOT_CONFIG_REG
+#    A0, 0D, 03, 54, 15, 00                RF_CLIF_CFG_BR_212_I_TXF    CLIF_TX_OVERSHOOT_CONFIG_REG
+#    A0, 0D, 06, 5A, 42, 98, 10, FF, FF    RF_CLIF_CFG_BR_424_I_TXF    CLIF_ANA_TX_AMPLITUDE_REG
+#    A0, 0D, 06, 5A, 4A, 63, 07, 01, 07    RF_CLIF_CFG_BR_424_I_TXF    CLIF_ANA_TX_SHAPE_CONTROL_REG
+#    A0, 0D, 03, 5A, 16, 00                RF_CLIF_CFG_BR_424_I_TXF    CLIF_TX_UNDERSHOOT_CONFIG_REG
+#    A0, 0D, 03, 5A, 15, 00                RF_CLIF_CFG_BR_424_I_TXF    CLIF_TX_OVERSHOOT_CONFIG_REG
+#    A0, 0D, 06, 98, 2F, AF, 05, 80, 17    RF_CLIF_GTM_B               CLIF_SIGPRO_ADCBCM_CONFIG_REG
+#    A0, 0D, 06, 9A, 42, 01, 00, F1, F1    RF_CLIF_GTM_FELICA          CLIF_ANA_TX_AMPLITUDE_REG
+#    A0, 0D, 06, 30, 44, A3, 90, 03, 00    RF_CLIF_CFG_TECHNO_T_RXF    CLIF_ANA_RX_REG
+#    A0, 0D, 06, 6C, 44, A1, 90, 03, 00    RF_CLIF_CFG_BR_106_T_RXA    CLIF_ANA_RX_REG
+#    A0, 0D, 06, 6C, 30, BF, 00, 20, 00    RF_CLIF_CFG_BR_106_T_RXA    CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#    A0, 0D, 06, 6C, 2F, 8F, 05, 80, 11    RF_CLIF_CFG_BR_106_T_RXA    CLIF_SIGPRO_ADCBCM_CONFIG_REG
+#    A0, 0D, 06, 70, 2F, 8F, 05, 80, 0D    RF_CLIF_CFG_BR_212_T_RXA    CLIF_SIGPRO_ADCBCM_CONFIG_REG
+#    A0, 0D, 06, 70, 30, 8F, 00, 04, 00    RF_CLIF_CFG_BR_212_T_RXA    CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#    A0, 0D, 06, 74, 2F, 6F, 05, 80, 0D    RF_CLIF_CFG_BR_424_T_RXA    CLIF_SIGPRO_ADCBCM_CONFIG_REG
+#    A0, 0D, 06, 74, 30, 8F, 00, 04, 00    RF_CLIF_CFG_BR_424_T_RXA    CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#    A0, 0D, 06, 78, 2F, 1F, 06, 80, 01    RF_CLIF_CFG_BR_848_T_RXA    CLIF_SIGPRO_ADCBCM_CONFIG_REG
+#    A0, 0D, 06, 78, 30, 9F, 00, 10, 00    RF_CLIF_CFG_BR_848_T_RXA    CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#    A0, 0D, 06, 78, 44, A0, 90, 03, 00    RF_CLIF_CFG_BR_848_T_RXA    CLIF_ANA_RX_REG
+#    A0, 0D, 03, 78, 47, 00                RF_CLIF_CFG_BR_848_T_RXA    CLIF_ANA_AGC_REG
+#    A0, 0D, 06, 7C, 2F, AF, 05, 80, 17    RF_CLIF_CFG_BR_106_T_RXB    CLIF_SIGPRO_ADCBCM_CONFIG_REG
+#    A0, 0D, 06, 7C, 30, BF, 00, 20, 00    RF_CLIF_CFG_BR_106_T_RXB    CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#    A0, 0D, 06, 7C, 44, A3, 90, 03, 00    RF_CLIF_CFG_BR_106_T_RXB    CLIF_ANA_RX_REG
+#    A0, 0D, 06, 7D, 30, 8F, 00, 04, 00    RF_CLIF_CFG_BR_106_T_RXB    CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#    A0, 0D, 06, 80, 2F, AF, 05, 80, 0D    RF_CLIF_CFG_BR_212_T_RXB    CLIF_SIGPRO_ADCBCM_CONFIG_REG
+#    A0, 0D, 06, 80, 44, A1, 90, 03, 00    RF_CLIF_CFG_BR_212_T_RXB    CLIF_ANA_RX_REG
+#    A0, 0D, 06, 84, 2F, AF, 05, 80, 0D    RF_CLIF_CFG_BR_424_T_RXB    CLIF_SIGPRO_ADCBCM_CONFIG_REG
+#    A0, 0D, 06, 84, 44, A1, 90, 03, 00    RF_CLIF_CFG_BR_424_T_RXB    CLIF_ANA_RX_REG
+#    A0, 0D, 06, 88, 2F, 7F, 04, 80, 0D    RF_CLIF_CFG_BR_848_T_RXB    CLIF_SIGPRO_ADCBCM_CONFIG_REG
+#    A0, 0D, 06, 88, 30, 8F, 00, 16, 00    RF_CLIF_CFG_BR_848_T_RXB    CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#    A0, 0D, 03, 88, 47, 00                RF_CLIF_CFG_BR_848_T_RXB    CLIF_ANA_AGC_REG
+#    A0, 0D, 06, 88, 44, A3, 90, 03, 00    RF_CLIF_CFG_BR_848_T_RXB    CLIF_ANA_RX_REG
+#    A0, 0D, 03, 0C, 48, 10                RF_CLIF_CFG_T_PASSIVE       CLIF_ANA_CLK_MAN_REG
+#    A0, 0D, 03, 10, 43, A0                RF_CLIF_CFG_T_ACTIVE        CLIF_ANA_PBF_CONTROL_REG
+#    A0, 0D, 06, 6A, 42, F8, 10, FF, FF    RF_CLIF_CFG_BR_106_T_TXA_A  CLIF_ANA_TX_AMPLITUDE_REG
+#    A0, 0D, 03, 6A, 16, 19                RF_CLIF_CFG_BR_106_T_TXA_A  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#    A0, 0D, 03, 6A, 15, 01                RF_CLIF_CFG_BR_106_T_TXA_A  CLIF_TX_OVERSHOOT_CONFIG_REG
+#    A0, 0D, 06, 6A, 4A, 53, 07, 01, 1B    RF_CLIF_CFG_BR_106_T_TXA_A  CLIF_ANA_TX_SHAPE_CONTROL_REG
+#    A0, 0D, 06, 8C, 42, 90, 10, FF, FF    RF_CLIF_CFG_BR_212_T_TXF_A  CLIF_ANA_TX_AMPLITUDE_REG
+#    A0, 0D, 06, 8C, 4A, 43, 07, 01, 07    RF_CLIF_CFG_BR_212_T_TXF_A  CLIF_ANA_TX_SHAPE_CONTROL_REG
+#    A0, 0D, 03, 8C, 16, 00                RF_CLIF_CFG_BR_212_T_TXF_A  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#    A0, 0D, 03, 8C, 15, 00                RF_CLIF_CFG_BR_212_T_TXF_A  CLIF_TX_OVERSHOOT_CONFIG_REG
+#    A0, 0D, 06, 92, 42, 98, 10, FF, FF    RF_CLIF_CFG_BR_424_T_TXF_A  CLIF_ANA_TX_AMPLITUDE_REG
+#    A0, 0D, 06, 92, 4A, 63, 07, 01, 07    RF_CLIF_CFG_BR_424_T_TXF_A  CLIF_ANA_TX_SHAPE_CONTROL_REG
+#    A0, 0D, 03, 92, 16, 00                RF_CLIF_CFG_BR_424_T_TXF_A  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#    A0, 0D, 03, 92, 15, 00                RF_CLIF_CFG_BR_424_T_TXF_A  CLIF_TX_OVERSHOOT_CONFIG_REG
+#    A0, 0D, 06, 0A, 30, BF, 00, 20, 00    RF_CLIF_CFG_I_ACTIVE        CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#    A0, 0D, 06, 0A, 2F, 8F, 05, 80, 11    RF_CLIF_CFG_I_ACTIVE        CLIF_SIGPRO_ADCBCM_CONFIG_REG
+#    A0, 0D, 03, 0A, 48, 10                RF_CLIF_CFG_I_ACTIVE        CLIF_ANA_CLK_MAN_REG
+#    A0, 0D, 06, 0A, 44, A3, 90, 03, 00    RF_CLIF_CFG_I_ACTIVE        CLIF_ANA_RX_REG
+
+# *** PLM(NO BOOSTER) FW VERSION = 08.01.1F ***
+NXP_RF_CONF_BLK_1={
+    20, 02, FC, 21,
+    A0, 0D, 03, 00, 40, 03,
+    A0, 0D, 03, 04, 43, A0,
+    A0, 0D, 03, 04, FF, 05,
+    A0, 0D, 06, 06, 44, A3, 90, 03, 00,
+    A0, 0D, 06, 06, 30, BF, 00, 20, 00,
+    A0, 0D, 06, 06, 2F, 8F, 05, 80, 11,
+    A0, 0D, 04, 06, 03, 00, 70,
+    A0, 0D, 03, 06, 48, 10,
+    A0, 0D, 03, 06, 43, 2C,
+    A0, 0D, 06, 06, 42, 00, 00, FF, FF,
+    A0, 0D, 06, 06, 41, 01, 00, 00, 00,
+    A0, 0D, 03, 06, 37, 00,
+    A0, 0D, 03, 06, 16, 00,
+    A0, 0D, 03, 06, 15, 00,
+    A0, 0D, 06, 06, FF, 05, 00, 06, 00,
+    A0, 0D, 06, 08, 44, 00, 00, 00, 00,
+    A0, 0D, 06, 20, 4A, 00, 00, 00, 00,
+    A0, 0D, 06, 20, 42, 88, 10, FF, FF,
+    A0, 0D, 03, 20, 16, 00,
+    A0, 0D, 03, 20, 15, 00,
+    A0, 0D, 06, 22, 44, 26, 00, 02, 00,
+    A0, 0D, 06, 22, 2D, 50, 44, 0C, 00,
+    A0, 0D, 04, 32, 03, 40, 3D,
+    A0, 0D, 06, 32, 42, F8, 10, FF, FF,
+    A0, 0D, 03, 32, 16, 19,
+    A0, 0D, 03, 32, 15, 01,
+    A0, 0D, 03, 32, 0D, 26,
+    A0, 0D, 03, 32, 14, 26,
+    A0, 0D, 06, 32, 4A, 53, 07, 01, 1B,
+    A0, 0D, 06, 34, 2D, DC, 80, 0C, 00,
+    A0, 0D, 06, 34, 34, 00, 00, E4, 03,
+    A0, 0D, 06, 34, 44, 2D, 00, 02, 00,
+    A0, 0D, 06, 35, 44, 21, 00, 02, 00
+}
+# *** PLM(NO BOOSTER) FW VERSION = 08.01.1F ***
+NXP_RF_CONF_BLK_2={
+    20, 02, F4, 1F,
+    A0, 0D, 06, 38, 4A, 56, 07, 01, 1B,
+    A0, 0D, 06, 38, 42, 68, 10, FF, FF,
+    A0, 0D, 03, 38, 16, 00,
+    A0, 0D, 03, 38, 15, 00,
+    A0, 0D, 06, 3A, 2D, 15, 57, 1F, 00,
+    A0, 0D, 06, 3C, 4A, 56, 07, 01, 1B,
+    A0, 0D, 06, 3C, 42, 68, 10, FF, FF,
+    A0, 0D, 03, 3C, 16, 00,
+    A0, 0D, 03, 3C, 15, 00,
+    A0, 0D, 06, 3E, 2D, 15, 88, 15, 00,
+    A0, 0D, 06, 40, 42, F0, 10, FF, FF,
+    A0, 0D, 03, 40, 0D, 03,
+    A0, 0D, 03, 40, 14, 03,
+    A0, 0D, 06, 40, 4A, 15, 07, 00, 00,
+    A0, 0D, 03, 40, 16, 00,
+    A0, 0D, 03, 40, 15, 00,
+    A0, 0D, 06, 42, 2D, DD, 33, 0F, 00,
+    A0, 0D, 06, 46, 44, 21, 00, 02, 00,
+    A0, 0D, 06, 46, 2D, 05, 48, 0C, 00,
+    A0, 0D, 06, 44, 4A, 43, 07, 01, 07,
+    A0, 0D, 06, 44, 42, 70, 10, FF, FF,
+    A0, 0D, 03, 44, 16, 00,
+    A0, 0D, 03, 44, 15, 00,
+    A0, 0D, 06, 4A, 44, 21, 00, 02, 00,
+    A0, 0D, 06, 4A, 2D, 05, 48, 0C, 00,
+    A0, 0D, 06, 48, 4A, 43, 07, 01, 07,
+    A0, 0D, 06, 48, 42, 88, 10, FF, FF,
+    A0, 0D, 03, 48, 16, 00,
+    A0, 0D, 03, 48, 15, 00,
+    A0, 0D, 06, 4E, 44, 21, 00, 02, 00,
+    A0, 0D, 06, 4E, 2D, 05, 48, 0C, 00
+}
+# *** PLM(NO BOOSTER) FW VERSION = 08.01.1F ***
+NXP_RF_CONF_BLK_3={
+    20, 02, F7, 1E,
+    A0, 0D, 06, 4C, 4A, 43, 07, 01, 07,
+    A0, 0D, 06, 4C, 42, 88, 10, FF, FF,
+    A0, 0D, 03, 4C, 16, 00,
+    A0, 0D, 03, 4C, 15, 00,
+    A0, 0D, 06, 52, 44, 21, 00, 02, 00,
+    A0, 0D, 06, 52, 2D, 05, 48, 0C, 00,
+    A0, 0D, 06, 50, 42, 90, 10, FF, FF,
+    A0, 0D, 06, 50, 4A, 32, 07, 01, 07,
+    A0, 0D, 03, 50, 16, 00,
+    A0, 0D, 03, 50, 15, 00,
+    A0, 0D, 06, 56, 2D, 05, CC, 0C, 00,
+    A0, 0D, 06, 56, 44, 22, 00, 02, 00,
+    A0, 0D, 06, 5C, 2D, 05, CC, 0C, 00,
+    A0, 0D, 06, 5C, 44, 21, 00, 02, 00,
+    A0, 0D, 06, 54, 42, 68, 10, FF, FF,
+    A0, 0D, 06, 54, 4A, 43, 07, 01, 07,
+    A0, 0D, 03, 54, 16, 00,
+    A0, 0D, 03, 54, 15, 00,
+    A0, 0D, 06, 5A, 42, 80, 10, FF, FF,
+    A0, 0D, 06, 5A, 4A, 63, 07, 01, 07,
+    A0, 0D, 03, 5A, 16, 00,
+    A0, 0D, 03, 5A, 15, 00,
+    A0, 0D, 06, 98, 2F, AF, 05, 80, 17,
+    A0, 0D, 06, 9A, 42, 01, 00, F1, F1,
+    A0, 0D, 06, 30, 44, A3, 90, 03, 00,
+    A0, 0D, 06, 6C, 44, A1, 90, 03, 00,
+    A0, 0D, 06, 6C, 30, BF, 00, 20, 00,
+    A0, 0D, 06, 6C, 2F, 8F, 05, 80, 11,
+    A0, 0D, 06, 70, 2F, 8F, 05, 80, 0D,
+    A0, 0D, 06, 70, 30, 8F, 00, 04, 00
+}
+# *** PLM(NO BOOSTER) FW VERSION = 08.01.1F ***
+NXP_RF_CONF_BLK_4={
+    20, 02, F7, 1E,
+    A0, 0D, 06, 74, 2F, 6F, 05, 80, 0D,
+    A0, 0D, 06, 74, 30, 8F, 00, 04, 00,
+    A0, 0D, 06, 78, 2F, 1F, 06, 80, 01,
+    A0, 0D, 06, 78, 30, 9F, 00, 10, 00,
+    A0, 0D, 06, 78, 44, A0, 90, 03, 00,
+    A0, 0D, 03, 78, 47, 00,
+    A0, 0D, 06, 7C, 2F, AF, 05, 80, 17,
+    A0, 0D, 06, 7C, 30, BF, 00, 20, 00,
+    A0, 0D, 06, 7C, 44, A3, 90, 03, 00,
+    A0, 0D, 06, 7D, 30, 8F, 00, 04, 00,
+    A0, 0D, 06, 80, 2F, AF, 05, 80, 0D,
+    A0, 0D, 06, 80, 44, A1, 90, 03, 00,
+    A0, 0D, 06, 84, 2F, AF, 05, 80, 0D,
+    A0, 0D, 06, 84, 44, A1, 90, 03, 00,
+    A0, 0D, 06, 88, 2F, 7F, 04, 80, 0D,
+    A0, 0D, 06, 88, 30, 8F, 00, 16, 00,
+    A0, 0D, 03, 88, 47, 00,
+    A0, 0D, 06, 88, 44, A3, 90, 03, 00,
+    A0, 0D, 03, 0C, 48, 10,
+    A0, 0D, 03, 10, 43, A0,
+    A0, 0D, 06, 6A, 42, F8, 10, FF, FF,
+    A0, 0D, 03, 6A, 16, 19,
+    A0, 0D, 03, 6A, 15, 01,
+    A0, 0D, 06, 6A, 4A, 53, 07, 01, 1B,
+    A0, 0D, 06, 8C, 42, 90, 10, FF, FF,
+    A0, 0D, 06, 8C, 4A, 43, 07, 01, 07,
+    A0, 0D, 03, 8C, 16, 00,
+    A0, 0D, 03, 8C, 15, 00,
+    A0, 0D, 06, 92, 42, 98, 10, FF, FF,
+    A0, 0D, 06, 92, 4A, 63, 07, 01, 07
+}
+
+# *** PLM(NO BOOSTER) FW VERSION = 08.01.1F ***
+NXP_RF_CONF_BLK_5={
+    20, 02, 2E, 06,
+    A0, 0D, 03, 92, 16, 00,
+    A0, 0D, 03, 92, 15, 00,
+    A0, 0D, 06, 0A, 30, BF, 00, 20, 00,
+    A0, 0D, 06, 0A, 2F, 8F, 05, 80, 11,
+    A0, 0D, 03, 0A, 48, 10,
+    A0, 0D, 06, 0A, 44, A3, 90, 03, 00
+}
+
+###############################################################################
+# Core configuration extensions
+# It includes
+# A002      - Clock Request
+#             0x00 - Disabled
+#             0x01 - Enabled
+# A003      - Clock Selection
+#             Please refer to User Manual
+# A004      - Clock Time Out
+#             Defined in ms
+# A00E      - Load Modulation Mode
+#             0x00 - PLM
+#             0x01 - ALM
+# A012      - SWP interface 2 configuration
+#             0x00 - SWP
+#             0x02 - DWP
+#             Please refer to User Manual
+# A040-A043 - Ultra Low Power Tag Detector
+#             Please refer to Application Note of ULPTD
+# A05E      - Jewel Reader
+#             Please refer to User Manual
+# A0CD      - SWP S1 line behavior
+#             Defined S1 High time out during Activation sequence
+# A0EC      - SWP1 interface
+#             0x00 - Disabled
+#             0x01 - Enabled
+# A0ED      - SWP2 interface
+#             0x00 - Disabled
+#             0x01 - Enabled
+NXP_CORE_CONF_EXTN={20, 02, 4D, 12,
+        A0, 02, 01, 01,
+        A0, 03, 01, 11,
+        A0, 04, 01, 02,
+        A0, 07, 01, 03,
+        A0, 0E, 01, 00,
+        A0, 11, 04, CD, 67, 22, 01,
+        A0, 12, 01, 00,
+        A0, 13, 01, 00,
+        A0, 40, 01, 01,
+        A0, 41, 01, 04,
+        A0, 42, 01, 19,
+        A0, 43, 01, 50,
+        A0, 47, 02, 88, 43,
+        A0, 61, 01, 2A,
+        A0, 5E, 01, 01,
+        A0, CD, 01, 1F,
+        A0, EC, 01, 01,
+        A0, ED, 01, 00
+        }
+
+###############################################################################
+# Core configuration rf field filter settings to enable set 01 ,to disable set to 00 last bit
+NXP_CORE_RF_FIELD={ 20, 02, 05, 01, A0, 62, 01, 01
+        }
+
+###############################################################################
+# Core configuration settings
+NXP_CORE_CONF={ 20, 02, 2B, 0D,
+        18, 01, 01,
+        21, 01, 00,
+        28, 01, 00,
+        30, 01, 08,
+        31, 01, 03,
+        33, 04, 01, 02, 03, 04,
+        50, 01, 02,
+        54, 01, 06,
+        5B, 01, 00,
+        60, 01, 0E,
+        80, 01, 01,
+        81, 01, 01,
+        82, 01, 0E
+        }
+
+###############################################################################
+# Core configuration extensions for firmware download mode
+# Clock setting A003 (0x08:XTAL, 0x11:PLL(19.2MHz))
+NXP_CORE_CONF_EXTN_CLK={20, 02, 05, 01, A0, 03, 01, 11}
+
+###############################################################################
+# Mifare Classic Key settings
+#NXP_CORE_MFCKEY_SETTING={20, 02, 25,04, A0, 51, 06, A0, A1, A2, A3, A4, A5,
+#                                     A0, 52, 06, D3, F7, D3, F7, D3, F7,
+#                                     A0, 53, 06, FF, FF, FF, FF, FF, FF,
+#                                     A0, 54, 06, 00, 00, 00, 00, 00, 00}
+
+###############################################################################
+# Default SE Options
+# No secure element 0x00
+# eSE               0x01
+# UICC              0x02
+NXP_DEFAULT_SE=0x02
+
+
+###############################################################################
+NXP_DEFAULT_NFCEE_TIMEOUT=0x06
+
+###############################################################################
+#Enable SWP full power mode when phone is power off
+NXP_SWP_FULL_PWR_ON=0x01
+
+###############################################################################
+#Chip type
+#PN547C2            0x01
+#PN65T              0x02
+NXP_NFC_CHIP=0x01
+
+###############################################################################
+#SWP Reader feature
+#Timeout in seconds
+NXP_SWP_RD_START_TIMEOUT=0x0A
+#Timeout in seconds
+NXP_SWP_RD_TAG_OP_TIMEOUT=0x01

--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -183,6 +183,10 @@ on post-fs
     # create the lost+found directories, so as to enforce our permissions
     mkdir /cache/lost+found 0770 root root
 
+    # Redirect pn544 to pn547
+    symlink /dev/pn547 /dev/pn544
+    chown nfc nfc /dev/pn547
+
 on post-fs-data
     # We chown/chmod /data again so because mount is run as root + defaults
     chown system system /data


### PR DESCRIPTION
Separate into 2 commits:
b67adbc3fc7ff17bcfa770792ef1ebce1618a0ad:
- Remove extracting blobs from Sony devices
- Add HAL source code module to build package
- Add config file (The config files are the same as the ones extracted from device.  Just add here in order to update/modify later)

28e067a0b71ceb9dab6249481d8ccc526d7c8440
- Our device uses device path /dev/pn547 but source built HAL expects /dev/pn544. Create a symlink to resolve this issue without editing source
